### PR TITLE
Compatibility with MCreator

### DIFF
--- a/src/main/java/cn/leomc/hltweaker/Utils.java
+++ b/src/main/java/cn/leomc/hltweaker/Utils.java
@@ -87,6 +87,24 @@ public class Utils {
         return false;
     }
 
+    public static Tier getHighestTier(Item item) {
+        ResourceLocation rl = ForgeRegistries.ITEMS.getKey(item);
+        if (!isItemOverridden(item))
+            return null;
+
+        ItemHarvestLevelOverride override = HarvestLevelTweaker.getManager().getOverride(rl);
+        var highestTier = (Tier) null;
+
+        for (TagKey<Block> tag : override.mineableTags()) {
+            Tier tier = override.getTier(tag);
+            if (highestTier == null || highestTier.getLevel() < tier.getLevel()) {
+                highestTier = tier;
+            }
+        }
+
+        return highestTier;
+    }
+
     public static boolean canHarvestBlock(BlockState state, Player player) {
         return !state.requiresCorrectToolForDrops()
                 || Utils.checkItemOverrides(player.getMainHandItem().getItem(), state)

--- a/src/main/java/cn/leomc/hltweaker/mixin/TieredItemMixin.java
+++ b/src/main/java/cn/leomc/hltweaker/mixin/TieredItemMixin.java
@@ -1,0 +1,25 @@
+package cn.leomc.hltweaker.mixin;
+
+import cn.leomc.hltweaker.Utils;
+import net.minecraft.world.item.Tier;
+import net.minecraft.world.item.TieredItem;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TieredItem.class)
+public abstract class TieredItemMixin {
+    @Inject(
+            method = "getTier",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void onGetTier(CallbackInfoReturnable<Tier> cir) {
+        var object = (TieredItem) (Object) this;
+        var highestTier = Utils.getHighestTier(object);
+        if (highestTier != null) {
+            cir.setReturnValue(highestTier);
+        }
+    }
+}

--- a/src/main/resources/hltweaker.mixins.json
+++ b/src/main/resources/hltweaker.mixins.json
@@ -9,6 +9,7 @@
     "DiggerItemMixin",
     "ItemMixin",
     "TiCHarvestTiersMixin",
+    "TieredItemMixin",
     "TierSortingRegistryAccessor",
     "TOPHarvestInfoToolsMixin"
   ],


### PR DESCRIPTION
Due to MCreator uses `getTier` directly in 2023.4 release https://github.com/MCreator/MCreator/blob/c495fe2d3e1a16239ad3b316cb50fb7db60c3a2e/plugins/generator-1.20.1/forge-1.20.1/templates/block/block.java.ftl#L485

all items returned their original tier and that means you can't increase mining level of a pickaxe when it's calculating available drops.

I suggest to add a mixin that will return tier with maximum level if there are any
